### PR TITLE
fixes issue with exported persist function

### DIFF
--- a/src/wda/persist.js
+++ b/src/wda/persist.js
@@ -226,5 +226,5 @@ async function retry(fn, retriesLeft = 3, interval = 10000, exponential = false)
 }
 
 module.exports = {
-	persist: retry((input) => persist(input), input.retries, input.interval, input.exponentialRetries),
+	persist: (input) => retry((input) => persist(input), input.retries, input.interval, input.exponentialRetries),
 }


### PR DESCRIPTION
- persist function was immediately executing `retry()`, instead of waiting for input
- fix was to wrap the `retry()` function in another function that takes `input` as its argument

note: not bumping package.json version since version `0.0.0-beta.6` was never published to NPM (and is broken)