### PR TITLE
beta.7: fixing bad execution of persist function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "@io-maana/lambda-boilerplates",
-  "version": "0.0.0-beta.5",
-  "lockfileVersion": 1
+  "version": "0.0.0-beta.7",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@io-maana/lambda-boilerplates",
+      "version": "0.0.0-beta.7",
+      "license": "MIT"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@io-maana/lambda-boilerplates",
-  "version": "0.0.0-beta.6",
+  "version": "0.0.0-beta.7",
   "description": "Library for various assistants that generate lambdas relying on boilerplate code",
   "main": "src/index.js",
   "scripts": {

--- a/src/wda/persist.js
+++ b/src/wda/persist.js
@@ -226,8 +226,8 @@ async function retry(fn, retriesLeft = 3, interval = 10000, exponential = false)
 }
 
 module.exports = {
-	persist: async (input) => await retry(
-		async () => await persist(input),
+	persist: (input) => retry(
+		() => persist(input),
 		input.retries,
 		input.interval,
 		input.exponentialRetries

--- a/src/wda/persist.js
+++ b/src/wda/persist.js
@@ -226,5 +226,10 @@ async function retry(fn, retriesLeft = 3, interval = 10000, exponential = false)
 }
 
 module.exports = {
-	persist: (input) => retry((input) => persist(input), input.retries, input.interval, input.exponentialRetries),
+	persist: async (input) => await retry(
+		async () => await persist(input),
+		input.retries,
+		input.interval,
+		input.exponentialRetries
+	),
 }


### PR DESCRIPTION
There were a few problems with the previous method for executing the persist/retry function:
1. the exported function of `persist` (that's wrapped with a retry) wasn't an `async` function, so `return persist(input);` in a lambda function wouldn't work because it's not returning a promise
2. the inline-declaration of `() => persist(input)` that's passed to `retry()` _also_ wasn't an async function, so it couldn't be `await`-ed in the `retry` function

